### PR TITLE
Cryptocb random wctestfix

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15282,7 +15282,7 @@ static wc_test_ret_t random_rng_test(void)
     {
         byte nonce[8] = { 0 };
         /* Test dynamic RNG. */
-        rng = wc_rng_new(nonce, (word32)sizeof(nonce), HEAP_HINT);
+        rng = wc_rng_new_ex(nonce, (word32)sizeof(nonce), HEAP_HINT, devId);
         if (rng == NULL)
             return WC_TEST_RET_ENC_ERRNO;
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -206,6 +206,7 @@ WOLFSSL_API int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 
 
 WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap);
+WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new_ex(byte* nonce, word32 nonceSz, void* heap, int devId);
 WOLFSSL_ABI WOLFSSL_API void wc_rng_free(WC_RNG* rng);
 
 


### PR DESCRIPTION
# Description

- Adds a new `_ex` function for RNG initialization that takes a devid argument
- Enables bare-metal targets to use cryptoCb for DRBG seed generation
- Adds test coverage for new RNG generate and seed functions


# Testing

Unit tests pass with new additions
